### PR TITLE
Fix engine particle spawn position

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ impl Plugin for GamePlugin {
             asteroids::wrap_asteroids,
             asteroids::bullet_asteroid_collision_system,
             particles::update_particles,
+            particles::engine_particle_system,
         ))
         .add_systems(FixedUpdate, physics::update_physics_state)
         .add_systems(

--- a/src/particles.rs
+++ b/src/particles.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use rand::prelude::*;
 
-use crate::physics::{MovementInputAccumulator, PhysicalRotation};
+use crate::physics::{InputAccumulator, MovementInputAccumulator, PhysicalRotation};
 
 #[derive(Component)]
 pub struct Particle {


### PR DESCRIPTION
## Summary
- show thruster particles behind the ship
- hook up engine particle system into main game plugin

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_686f4b0b06448329abd5122b6ce25e99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new engine thrust particle effects that visually simulate engine exhaust when ships accelerate.
  * Ships now emit dynamic orange particles from their engines during forward movement, enhancing visual feedback and immersion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->