### PR TITLE
Fix engine particle spawn position

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ impl Plugin for GamePlugin {
             asteroids::wrap_asteroids,
             asteroids::bullet_asteroid_collision_system,
             particles::update_particles,
+            particles::engine_particle_system,
         ))
         .add_systems(FixedUpdate, physics::update_physics_state)
         .add_systems(

--- a/src/particles.rs
+++ b/src/particles.rs
@@ -1,6 +1,8 @@
 use bevy::prelude::*;
 use rand::prelude::*;
 
+use crate::physics::{InputAccumulator, MovementInputAccumulator, PhysicalRotation};
+
 #[derive(Component)]
 pub struct Particle {
     pub lifetime: Timer,
@@ -149,4 +151,62 @@ pub fn spawn_asteroid_destruction_particles(
         sparks_count,
         spark_color,
     );
+}
+
+/// Spawns a small burst of particles to simulate engine thrust.
+pub fn spawn_engine_particle(
+    commands: &mut Commands,
+    meshes: &mut ResMut<Assets<Mesh>>,
+    materials: &mut ResMut<Assets<ColorMaterial>>,
+    position: Vec2,
+    direction: Vec2,
+) {
+    let mut rng = thread_rng();
+
+    let particle_size = rng.gen_range(1.0..3.0);
+    let lifetime = rng.gen_range(0.2..0.4);
+
+    // Particles travel opposite the thrust direction with slight variation
+    let velocity_variance = Vec2::new(
+        rng.gen_range(-0.2..0.2),
+        rng.gen_range(-0.2..0.2),
+    );
+    let velocity = (direction + velocity_variance) * rng.gen_range(60.0..100.0);
+
+    let particle_mesh = meshes.add(Circle::new(particle_size));
+    let particle_material = materials.add(Color::srgb(1.0, 0.5, 0.2));
+
+    commands.spawn((
+        Particle::new(lifetime, particle_size),
+        ParticleVelocity::new(velocity, 2.0),
+        ColorMesh2dBundle {
+            mesh: particle_mesh.into(),
+            material: particle_material,
+            transform: Transform::from_translation(position.extend(0.1)),
+            ..default()
+        },
+    ));
+}
+
+/// System that emits engine particles when the ship is applying thrust.
+pub fn engine_particle_system(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    query: Query<(&MovementInputAccumulator, &Transform, &PhysicalRotation)>,
+) {
+    for (input_acc, transform, rotation) in query.iter() {
+        let input = input_acc.get();
+        if input.y > 0.0 {
+            let forward = Vec2::new(-rotation.0.sin(), rotation.0.cos());
+            let spawn_pos = transform.translation.truncate() - forward * 20.0;
+            spawn_engine_particle(
+                &mut commands,
+                &mut meshes,
+                &mut materials,
+                spawn_pos,
+                -forward,
+            );
+        }
+    }
 }

--- a/tests/physics_tests.rs
+++ b/tests/physics_tests.rs
@@ -1,6 +1,13 @@
-use asteroids_rust::physics::{PhysicalRotation, SHIP_SPEED};
+use asteroids_rust::particles::{Particle, engine_particle_system};
+use asteroids_rust::physics::{
+    MAX_VELOCITY, MovementInputAccumulator, PhysicalRotation, Velocity, apply_movement,
+};
+use bevy::ecs::schedule::Schedule;
+use bevy::ecs::world::World;
 use bevy::prelude::*;
+use bevy::time::Fixed;
 use std::sync::Once;
+use std::time::Duration;
 use tracing_subscriber::fmt;
 
 static INIT: Once = Once::new();
@@ -11,9 +18,7 @@ pub fn init_tracing() {
         tracing_log::LogTracer::init().expect("Failed to install LogTracer");
 
         // Build the subscriber with desired configuration
-        let subscriber = fmt()
-            .with_max_level(tracing::Level::INFO)
-            .finish();
+        let subscriber = fmt().with_max_level(tracing::Level::INFO).finish();
 
         // Set this subscriber as the global default
         tracing::subscriber::set_global_default(subscriber)
@@ -27,13 +32,14 @@ fn run_all_tests_in_order() {
     init_tracing();
 
     test_forward_vector_calculation();
-    test_velocity_normalization();
+    test_apply_movement_clamp();
+    test_engine_particle_spawn();
 }
 
 /// Tests the calculation of the forward vector based on rotation
 fn test_forward_vector_calculation() {
     init_tracing();
-    
+
     let rotation = PhysicalRotation(0.0);
     let forward = Vec2::new(-rotation.0.sin(), rotation.0.cos());
     info!("Testing forward vector calculation:");
@@ -43,18 +49,50 @@ fn test_forward_vector_calculation() {
     assert_eq!(forward, Vec2::new(0.0, 1.0));
 }
 
-/// Tests the normalization of velocity to ensure consistent speed
-fn test_velocity_normalization() {
+/// Tests that applying thrust accelerates the ship and clamps to the max speed
+fn test_apply_movement_clamp() {
     init_tracing();
-    
-    let input = Vec2::new(3.0, 4.0);
-    let velocity = input.normalize_or_zero() * SHIP_SPEED;
-    let speed_diff = (velocity.length() - SHIP_SPEED).abs();
-    info!("Testing velocity normalization:");
-    info!("  Input vector: {:?}", input);
-    info!("  Normalized velocity: {:?}", velocity);
-    info!("  Velocity length: {}", velocity.length());
-    info!("  Expected length: {}", SHIP_SPEED);
-    info!("  Difference: {}", speed_diff);
-    assert!(speed_diff < f32::EPSILON);
+
+    let mut world = World::new();
+    world.spawn((
+        MovementInputAccumulator { value: Vec2::Y },
+        PhysicalRotation(0.0),
+        Velocity(Vec3::ZERO),
+    ));
+    world.insert_resource(Time::<Fixed>::default());
+    {
+        let mut time = world.resource_mut::<Time<Fixed>>();
+        time.advance_by(Duration::from_secs_f32(1.0));
+    }
+
+    let mut schedule = Schedule::default();
+    schedule.add_systems(apply_movement);
+    schedule.run(&mut world);
+
+    let velocity = world.query::<&Velocity>().single(&world).0;
+    let expected = MAX_VELOCITY;
+    info!("Velocity after apply_movement: {}", velocity.y);
+    assert!((velocity.y - expected).abs() < f32::EPSILON);
+}
+
+/// Tests that engine particles spawn behind the ship when thrusting
+fn test_engine_particle_spawn() {
+    init_tracing();
+
+    let mut world = World::new();
+    world.spawn((
+        MovementInputAccumulator { value: Vec2::Y },
+        Transform::default(),
+        PhysicalRotation(0.0),
+    ));
+    world.insert_resource(Assets::<Mesh>::default());
+    world.insert_resource(Assets::<ColorMaterial>::default());
+
+    let mut schedule = Schedule::default();
+    schedule.add_systems(engine_particle_system);
+    schedule.run(&mut world);
+
+    let mut query = world.query::<(&Particle, &Transform)>();
+    let (_, transform) = query.single(&world);
+    assert_eq!(transform.translation.truncate(), Vec2::new(0.0, -20.0));
 }


### PR DESCRIPTION
## Summary
- show thruster particles behind the ship
- hook up engine particle system into main game plugin
- import `InputAccumulator` for compilation
- add regression tests for movement and particle spawning

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_686f4b0b06448329abd5122b6ce25e99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added engine thrust particle effects that emit orange particles behind moving entities when thrust is applied.

* **Tests**
  * Introduced new tests to verify velocity clamping and correct spawning of engine thrust particles.
  * Updated test coverage to ensure particle effects and movement logic work as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->